### PR TITLE
denied_resource_group_names is optional

### DIFF
--- a/azureenergylabelerlib/entities.py
+++ b/azureenergylabelerlib/entities.py
@@ -358,7 +358,7 @@ class Subscription(FindingParserLabeler):
     def __init__(self,
                  credential,
                  data,
-                 denied_resource_group_names):
+                 denied_resource_group_names=None):
         self._credential = credential
         self._data = data
         self._threshold = SUBSCRIPTION_THRESHOLDS


### PR DESCRIPTION
denied_resource_group_names  is optional in the rest of the code, so also should be in Subscription