### PR TITLE
pin policy api version for use of policy exemptions

### DIFF
--- a/azureenergylabelerlib/entities.py
+++ b/azureenergylabelerlib/entities.py
@@ -408,7 +408,7 @@ class Subscription(FindingParserLabeler):
     @cached(cache=TTLCache(maxsize=1000, ttl=600))
     def exempted_policies(self):
         """Policies exempted for this subscription."""
-        policy_client = PolicyClient(credential=self._credential, subscription_id=self.subscription_id)
+        policy_client = PolicyClient(credential=self._credential, subscription_id=self.subscription_id, api_version="2020-07-01-preview")
         return list(policy_client.policy_exemptions.list())
 
     def get_open_findings(self, findings):


### PR DESCRIPTION
Code is calling an invalid api version:
`azure_energy_labeler_cli[58] ERROR API version 2022-06-01 does not have operation group 'policy_exemptions'`

pin the verison to a working one https://learn.microsoft.com/en-us/python/api/azure-mgmt-resource/azure.mgmt.resource.policyclient?view=azure-python#azure-mgmt-resource-policyclient-policy-exemptions